### PR TITLE
suppress unnecessary ui: files, file tags, image tags

### DIFF
--- a/dashboard/modules/@apostrophecms/file-tag/index.js
+++ b/dashboard/modules/@apostrophecms/file-tag/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  options: {
+    quickCreate: false
+  },
+  methods(self) {
+    return {
+      addToAdminBar() {}
+    };
+  }
+};

--- a/dashboard/modules/@apostrophecms/file/index.js
+++ b/dashboard/modules/@apostrophecms/file/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  options: {
+    quickCreate: false
+  },
+  methods(self) {
+    return {
+      addToAdminBar() {}
+    };
+  }
+};

--- a/dashboard/modules/@apostrophecms/image-tag/index.js
+++ b/dashboard/modules/@apostrophecms/image-tag/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  options: {
+    quickCreate: false
+  },
+  methods(self) {
+    return {
+      addToAdminBar() {}
+    };
+  }
+};

--- a/dashboard/modules/@apostrophecms/image/index.js
+++ b/dashboard/modules/@apostrophecms/image/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  fields: {
+    remove: [ '_tags' ]
+  },
+  filters: {
+    remove: [ '_tags' ]
+  }
+};


### PR DESCRIPTION
PRO-25

While we do have images here, they are really only used for site thumbnails, so image tags don't seem necessary either.