### PR TITLE
PRO-1006 put the link and script tags for the theme assets back

### DIFF
--- a/sites/views/layout.html
+++ b/sites/views/layout.html
@@ -31,7 +31,9 @@
 {% endblock %}
 
 {% block extraBody %}
+  {% if data.isDev %}
     {# NOTE: Allows webpack to do hot module reloading.
       Can remove if you're not webpacking your assets. #}
     <script src="http://localhost:9002/wp/theme-{{ data.theme }}.js"></script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Not sure if we removed them or what, but I was able to copy and paste these straight from the a2 boilerplate as the approach is exactly the same. Verified success.