### PR TITLE
show default label when no fonts exist PRO-988

### DIFF
--- a/sites/modules/@apostrophecms/global/ui/apos/components/AssemblyInputFontFamily.vue
+++ b/sites/modules/@apostrophecms/global/ui/apos/components/AssemblyInputFontFamily.vue
@@ -50,12 +50,12 @@ export default {
         value: ''
       });
     }
-    choices = [ ...choices, ...apos.global.fontFamilies.map(family => {
+    choices = [ ...choices, ...((apos.global.fontFamilies || []).map(family => {
       return {
         value: family,
         label: family
       };
-    }) ];
+    })) ];
     return {
       choices
     };


### PR DESCRIPTION
Fixes crash that prevented "Default" from coming up if no google fonts were ever configured.