### PR TITLE
eliminate a few remaining vestiges of webpack and the need for ENV=dev

### DIFF
--- a/dashboard/modules/@apostrophecms/page/index.js
+++ b/dashboard/modules/@apostrophecms/page/index.js
@@ -31,20 +31,9 @@ module.exports = {
     ],
     quickCreate: false
   },
-  handlers(self, options) {
-    return {
-      '@apostrophecms/page:beforeSend': {
-        webpack(req) {
-          req.data.isDev = process.env.ENV === 'dev';
-        }
-      }
-    };
-  },
   methods(self, options) {
     return {
       async serveNotFound(req) {
-        // If a non-logged-in user hits a 404/login protected page (home), redirect them to /login
-        req.data.isDev = process.env.ENV === 'dev';
         if (!req.user) {
           req.redirect = '/login';
           return;

--- a/deployment/before-deploying
+++ b/deployment/before-deploying
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This project requires a webpack build. Assembly will
+# This project requires an asset build. Assembly will
 # run this script at the appropriate step in the deployment
 # process.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "//": "because nodemon insists on executing 'start' if it exists, we must distinguish production",
     "production-start": "APOS_UPLOADFS_ASSETS=1 NODE_ENV=production npm run start",
     "start": "node app",
-    "dev": "ENV=dev nodemon"
+    "dev": "nodemon"
   },
   "repository": {
     "type": "git",

--- a/sites/modules/@apostrophecms/home-page/views/page.html
+++ b/sites/modules/@apostrophecms/home-page/views/page.html
@@ -12,10 +12,10 @@ You can use normal <a href="https://docs.apostrophecms.org/">Apostrophe developm
 The master <a href="https://sass-lang.com/">SASS stylesheet</a> for the default theme is located at: <code>modules/theme-default/src/scss/index.scss</code>
 </p>
 <p>
-The master JavaScript browser-side entry point for the default theme is located at: <code>modules/theme-default/src/js/index.js</code>
+The master JavaScript browser-side entry point for the default theme is located at: <code>sites/modules/theme-default/ui/src/index.js</code>
 </p>
 <p>
-The webpack configuration is located at: <code>webpack.config.js</code>
+The master Sass SCSS browser-side entry point for the default theme is located at: <code>sites/modules/theme-default/ui/src/index.scss</code>
 </p>
 {% area data.page, 'main' %}
 {% endblock %}

--- a/sites/modules/@apostrophecms/page/index.js
+++ b/sites/modules/@apostrophecms/page/index.js
@@ -14,8 +14,7 @@ module.exports = {
   handlers(self, options) {
     return {
       '@apostrophecms/page:beforeSend': {
-        devAndTheme(req) {
-          req.data.isDev = process.env.ENV === 'dev';
+        setTheme(req) {
           req.data.theme = self.apos.options.theme;
         }
       }

--- a/sites/modules/theme-alternate/index.js
+++ b/sites/modules/theme-alternate/index.js
@@ -1,6 +1,5 @@
 module.exports = {
-  // The webpack build pushes assets to this module in production.
-  // It is also not a bad place to add theme specific
+  // This is a good place to add theme specific
   // variations on helpers; since the active theme
   // is aliased as `apos.theme` these can be called easily
   options: {

--- a/sites/modules/theme-default/index.js
+++ b/sites/modules/theme-default/index.js
@@ -1,6 +1,5 @@
 module.exports = {
-  // The webpack build pushes assets to this module in production.
-  // It is also not a bad place to add theme specific
+  // This is a good place to add theme specific
   // variations on helpers; since the active theme
   // is aliased as `apos.theme` these can be called easily
   options: {


### PR DESCRIPTION
@abea your question led me to pull on the thread a little and discover leftover vestiges of webpack support that should not be here and could cause confusion or even lead people to expect a webpack.config.js they can't find. Also, no need for ENV=dev when running nodemon, it's the default in all remaining code that cares about `process.env.ENV`.

I have verified this causes no problems with `npm run dev` but we'll need to validate it also causes no startup problems when pushed to staging before adding it to the 1.1.0 release into `main` and sharing with Michelin. I don't think a full regression test is warranted for this dead code and doc cleanup but we should kick the tires.