### PR TITLE
bring private dashboards flag to develop

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -3,6 +3,7 @@ const domains = require('../domains.js');
 module.exports = {
   stagingBaseUrl: `https://dashboard.${domains.staging}`,
   prodBaseUrl: `https://dashboard.${domains.prod}`,
+  privateDashboards: true,
   modules: {
     '@apostrophecms/attachment': {
       options: {


### PR DESCRIPTION
I checked a diff and this is s the only change to bring back from main/production, the rest is production-only npm deps