### PR TITLE
if we dont have a script or a global doc skip parsing

### DIFF
--- a/sites/modules/@apostrophecms/global/index.js
+++ b/sites/modules/@apostrophecms/global/index.js
@@ -39,6 +39,9 @@ module.exports = {
     return {
       beforeSave: {
         addFontFamilies(req, doc, options) {
+          if (!doc.googleFontScript && (!req.data.global || !req.data.global.googleFontScript)) {
+            return;
+          }
           try {
             const choices = [];
             let parsedQuery = null;


### PR DESCRIPTION
This should bail when
- we have no script and never had a script (nothing to parse, nothing to update)
- we have no script and the global doc doesn't yet exist (new site spinup)