### PR TITLE
fix obvious bug: assuming window.apos.modules exists when logged out

### DIFF
--- a/sites/modules/theme-demo/ui/src/index.js
+++ b/sites/modules/theme-demo/ui/src/index.js
@@ -11,7 +11,7 @@ export default () => {
 
   const $body = document.getElementsByTagName('body')[0];
 
-  const adminBar = window.apos.modules['@apostrophecms/admin-bar'];
+  const adminBar = window.apos.modules?.['@apostrophecms/admin-bar'];
 
   if (adminBar && !$body.classList.contains(isLoggedIn)) {
     apos.util.addClass($body, isLoggedIn);

--- a/sites/modules/theme-demo/ui/src/js/placeholder.js
+++ b/sites/modules/theme-demo/ui/src/js/placeholder.js
@@ -1,7 +1,7 @@
 export default () => {
   const hiddenClass = 'is-hidden';
 
-  const adminBar = window.apos.modules['@apostrophecms/admin-bar'];
+  const adminBar = window.apos.modules?.['@apostrophecms/admin-bar'];
 
   if (adminBar) {
     setInterval(togglePlaceholder, 300);


### PR DESCRIPTION
just a bad assumption that produces an error message that can lead to confusion about other bugs