### PR TITLE
Prepare for npm v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@apostrophecms-pro/multisite-dashboard": "^1.4.0",
     "@apostrophecms-pro/palette": "^4.3.2",
     "@apostrophecms/favicon": "^1.1.2",
-    "@apostrophecms/vite": "apostrophecms/vite#fix-windows-1",
+    "@apostrophecms/vite": "^1.1.1",
     "@opentelemetry/auto-instrumentations-node": "^0.62.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
     "@opentelemetry/resources": "^2.0.1",
@@ -46,7 +46,7 @@
     "swiper": "^11.1.3"
   },
   "devDependencies": {
-    "@apostrophecms-pro/cypress-tools": "1.0.0-beta.19",
+    "@apostrophecms-pro/cypress-tools": "1.0.0-beta.29",
     "autoprefixer": "^10.4.20",
     "cypress": "^13.16.0",
     "eslint-config-apostrophe": "^6.0.1",
@@ -54,5 +54,16 @@
     "nodemon": "^3.1.7",
     "stylelint": "^16.6.1",
     "stylelint-config-apostrophe": "^4.2.0"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "better-sqlite3": true,
+    "cypress": true,
+    "esbuild": true,
+    "fsevents": true,
+    "protobufjs": true,
+    "sharp": true,
+    "unrs-resolver": true,
+    "vue-demi": true
   }
 }


### PR DESCRIPTION
- Add `allowScripts` to `package.json`.
- Fix outdated vite dependency
- Fix outdated cypress-tools dependency